### PR TITLE
Update solution to calculate adjusted R^2

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,6 @@ def stepwise_selection(X, y,
     return included
 ```
 
-    /Users/lore.dirick/anaconda3/lib/python3.6/site-packages/statsmodels/compat/pandas.py:56: FutureWarning: The pandas.core.datetools module is deprecated and will be removed in a future version. Please use the pandas.tseries module instead.
-      from pandas.core import datetools
-
-
 
 ```python
 X = boston_features
@@ -177,10 +173,10 @@ model.summary()
   <th>Method:</th>             <td>Least Squares</td>  <th>  F-statistic:       </th> <td>   215.7</td> 
 </tr>
 <tr>
-  <th>Date:</th>             <td>Mon, 15 Oct 2018</td> <th>  Prob (F-statistic):</th> <td>2.69e-156</td>
+  <th>Date:</th>             <td>Thu, 08 Nov 2018</td> <th>  Prob (F-statistic):</th> <td>2.69e-156</td>
 </tr>
 <tr>
-  <th>Time:</th>                 <td>21:15:33</td>     <th>  Log-Likelihood:    </th> <td> -1461.3</td> 
+  <th>Time:</th>                 <td>13:29:19</td>     <th>  Log-Likelihood:    </th> <td> -1461.3</td> 
 </tr>
 <tr>
   <th>No. Observations:</th>      <td>   506</td>      <th>  AIC:               </th> <td>   2941.</td> 
@@ -260,10 +256,6 @@ selector = RFE(linreg, n_features_to_select = 5)
 selector = selector.fit(X, y)
 ```
 
-    /Users/lore.dirick/anaconda3/lib/python3.6/site-packages/sklearn/utils/validation.py:578: DataConversionWarning: A column-vector y was passed when a 1d array was expected. Please change the shape of y to (n_samples, ), for example using ravel().
-      y = column_or_1d(y, warn=True)
-
-
 
 ```python
 selector.support_ 
@@ -314,7 +306,7 @@ $R^2_{adj}= 1-(1-R^2)\dfrac{n-1}{n-p-1}$
 SS_Residual = np.sum((y-yhat)**2)
 SS_Total = np.sum((y-np.mean(y))**2)
 r_squared = 1 - (float(SS_Residual))/SS_Total
-adjusted_r_squared = 1 - (1-r_squared)*(len(y)-1)/(len(y)-X.shape[1]-1)
+adjusted_r_squared = 1 - (1-r_squared)*(len(y)-1)/(len(y)-X[selected_columns].shape[1]-1)
 ```
 
 
@@ -338,7 +330,7 @@ adjusted_r_squared
 
 
 
-    price    0.735652
+    price    0.740411
     dtype: float64
 
 

--- a/index.ipynb
+++ b/index.ipynb
@@ -46,8 +46,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -109,18 +111,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/lore.dirick/anaconda3/lib/python3.6/site-packages/statsmodels/compat/pandas.py:56: FutureWarning: The pandas.core.datetools module is deprecated and will be removed in a future version. Please use the pandas.tseries module instead.\n",
-      "  from pandas.core import datetools\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import statsmodels.api as sm\n",
     "\n",
@@ -177,8 +170,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "X = boston_features\n",
@@ -187,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -222,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -240,10 +235,10 @@
        "  <th>Method:</th>             <td>Least Squares</td>  <th>  F-statistic:       </th> <td>   215.7</td> \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Date:</th>             <td>Mon, 15 Oct 2018</td> <th>  Prob (F-statistic):</th> <td>2.69e-156</td>\n",
+       "  <th>Date:</th>             <td>Thu, 08 Nov 2018</td> <th>  Prob (F-statistic):</th> <td>2.69e-156</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Time:</th>                 <td>21:15:33</td>     <th>  Log-Likelihood:    </th> <td> -1461.3</td> \n",
+       "  <th>Time:</th>                 <td>13:29:19</td>     <th>  Log-Likelihood:    </th> <td> -1461.3</td> \n",
        "</tr>\n",
        "<tr>\n",
        "  <th>No. Observations:</th>      <td>   506</td>      <th>  AIC:               </th> <td>   2941.</td> \n",
@@ -313,8 +308,8 @@
        "Dep. Variable:                  price   R-squared:                       0.776\n",
        "Model:                            OLS   Adj. R-squared:                  0.773\n",
        "Method:                 Least Squares   F-statistic:                     215.7\n",
-       "Date:                Mon, 15 Oct 2018   Prob (F-statistic):          2.69e-156\n",
-       "Time:                        21:15:33   Log-Likelihood:                -1461.3\n",
+       "Date:                Thu, 08 Nov 2018   Prob (F-statistic):          2.69e-156\n",
+       "Time:                        13:29:19   Log-Likelihood:                -1461.3\n",
        "No. Observations:                 506   AIC:                             2941.\n",
        "Df Residuals:                     497   BIC:                             2979.\n",
        "Df Model:                           8                                         \n",
@@ -343,7 +338,7 @@
        "\"\"\""
       ]
      },
-     "execution_count": 5,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -379,18 +374,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/lore.dirick/anaconda3/lib/python3.6/site-packages/sklearn/utils/validation.py:578: DataConversionWarning: A column-vector y was passed when a 1d array was expected. Please change the shape of y to (n_samples, ), for example using ravel().\n",
-      "  y = column_or_1d(y, warn=True)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from sklearn.feature_selection import RFE\n",
     "from sklearn.linear_model import LinearRegression\n",
@@ -402,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -412,7 +398,7 @@
        "       False, False, False, False, False])"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -430,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -439,7 +425,7 @@
        "LinearRegression(copy_X=True, fit_intercept=True, n_jobs=1, normalize=False)"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -458,8 +444,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "yhat = linreg.predict(X[selected_columns])"
@@ -487,19 +475,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "SS_Residual = np.sum((y-yhat)**2)\n",
     "SS_Total = np.sum((y-np.mean(y))**2)\n",
     "r_squared = 1 - (float(SS_Residual))/SS_Total\n",
-    "adjusted_r_squared = 1 - (1-r_squared)*(len(y)-1)/(len(y)-X.shape[1]-1)"
+    "adjusted_r_squared = 1 - (1-r_squared)*(len(y)-1)/(len(y)-X[selected_columns].shape[1]-1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -509,7 +499,7 @@
        "dtype: float64"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -520,17 +510,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "price    0.735652\n",
+       "price    0.740411\n",
        "dtype: float64"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -579,7 +569,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I removed the pandas warning message and updated the equation to calculate the adjusted R^2.  It was calculated using the incorrect number of columns.   We filtered the dataframe down from 14 columns to 5 columns, but it was still calculating adjusted R^2 with the entire dataframe and not the filtered dataframe.  